### PR TITLE
Add dashboard Compose deployment, tests, and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,9 +154,20 @@ Conductor runs on a managed server. The dashboard exposes:
 
 ### Getting started
 
+Refer to [docs/dashboard.md](docs/dashboard.md) for a complete walkthrough that
+covers local execution and Docker Compose usage. The short version:
+
 ```bash
+pip install -e .
 pip install -r dashboard/requirements.txt
 streamlit run dashboard/app.py
+```
+
+To run the dashboard in a container use the provided Compose service:
+
+```bash
+cd deploy
+docker compose up dashboard
 ```
 
 The application relies on the same workspace files, so any flow or configuration

--- a/conductor/orchestrator/__init__.py
+++ b/conductor/orchestrator/__init__.py
@@ -154,8 +154,14 @@ class FlowHandle:
         payload: Any = None,
         *,
         metadata: Optional[Dict[str, Any]] = None,
+        schedule_id: Optional[str] = None,
     ) -> asyncio.Task[FlowExecution]:
-        return self._orchestrator.run_flow_in_background(self.name, payload=payload, metadata=metadata)
+        return self._orchestrator.run_flow_in_background(
+            self.name,
+            payload=payload,
+            metadata=metadata,
+            schedule_id=schedule_id,
+        )
 
     def schedule(
         self,

--- a/deploy/dashboard.Dockerfile
+++ b/deploy/dashboard.Dockerfile
@@ -1,0 +1,16 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+COPY .. /app
+
+RUN pip install --no-cache-dir -e . \
+    && pip install --no-cache-dir -r dashboard/requirements.txt
+
+ENV PYTHONPATH=/app \
+    STREAMLIT_SERVER_ADDRESS=0.0.0.0 \
+    STREAMLIT_SERVER_PORT=8501
+
+EXPOSE 8501
+
+ENTRYPOINT ["streamlit", "run", "dashboard/app.py"]

--- a/deploy/docker-compose.yaml
+++ b/deploy/docker-compose.yaml
@@ -19,5 +19,20 @@ services:
       - --payload-file
       - payloads://latest.json
 
+  dashboard:
+    build:
+      context: ..
+      dockerfile: deploy/dashboard.Dockerfile
+    restart: unless-stopped
+    environment:
+      CONDUCTOR_GLOBAL_CONFIG: /etc/conductor/global.json
+      STREAMLIT_SERVER_PORT: 8501
+    ports:
+      - "8501:8501"
+    volumes:
+      - ./config:/etc/conductor:ro
+    depends_on:
+      - conductor
+
 volumes:
   conductor-cache:

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -1,0 +1,106 @@
+# Conductor Dashboard
+
+The Conductor dashboard is a Streamlit application that exposes the main
+orchestration capabilities of Conductor through an interactive interface. It
+lets you inspect registered flows, trigger ad-hoc executions, configure
+schedules, and adjust the global settings that drive your automation.
+
+This guide explains how to run the dashboard locally—either directly with
+Python or through Docker Compose—and describes the most important
+sections of the UI.
+
+## Prerequisites
+
+* Python 3.11 or later if you plan to run the application locally.
+* Docker and Docker Compose v2 for containerised deployments.
+* Access to the flows and configuration files that you want to manage. The
+  examples below assume the repository root as the working directory.
+
+## Running the dashboard locally
+
+1. Install the dashboard dependencies. The Streamlit app depends on the core
+   Conductor package as well as the UI extras listed in
+   `dashboard/requirements.txt`.
+
+   ```bash
+   python -m venv .venv
+   source .venv/bin/activate
+   pip install -e .
+   pip install -r dashboard/requirements.txt
+   ```
+
+2. Start Streamlit from the repository root:
+
+   ```bash
+   streamlit run dashboard/app.py
+   ```
+
+3. Open your browser at <http://localhost:8501>. The dashboard will discover
+   flows and schedules using the same working directory as the process.
+
+### Environment variables
+
+The dashboard honours the environment variables used by Conductor. Notable
+settings include:
+
+* `CONDUCTOR_GLOBAL_CONFIG` – path to a global configuration file loaded when
+  the app starts.
+* `CONDUCTOR_CODE_LOCATIONS` – additional directories where flow definitions
+  can be discovered.
+
+When running locally you can export these variables before launching the app to
+customise its behaviour.
+
+## Running the dashboard with Docker Compose
+
+The repository ships with a ready-to-use Docker Compose service that exposes
+Streamlit on port 8501. From the repository root:
+
+```bash
+cd deploy
+docker compose up dashboard
+```
+
+The first run builds an image containing the Conductor package and the
+Streamlit dependencies. Once the service is up, open
+<http://localhost:8501> to access the dashboard.
+
+The Compose service mounts the `deploy/config` directory into the container so
+that you can share configuration files between the dashboard and the core
+conductor service. Adjust the volume mappings if your flows live elsewhere.
+
+### Customising the service
+
+You can override the following environment variables in `docker-compose.yaml`
+if required:
+
+* `STREAMLIT_SERVER_PORT` – change the HTTP port exposed by Streamlit.
+* `CONDUCTOR_GLOBAL_CONFIG` – specify the default global configuration file to
+  load.
+
+For production deployments consider publishing the container image to a
+registry and referencing it in the Compose file instead of building it locally.
+
+## Navigating the UI
+
+The sidebar exposes shortcuts to the major sections of the dashboard:
+
+* **Monitoraggio** – overview of active and recent flow runs.
+* **Flow registrati** – inspect registered flows and view their definitions.
+* **Scheduler** – manage recurring executions and upcoming triggers.
+* **Flow Designer** – design new flows or edit existing ones using the visual
+  editor.
+* **Global settings** – review and update the global Conductor configuration.
+
+Use the *Aggiorna* button in the sidebar to refresh the runtime state and the
+*Reset sessione* action to clear cached data when experimenting.
+
+## Troubleshooting
+
+*If the dashboard cannot discover your flows*, double-check that the process or
+container has access to the directories that store the JSON/TOML definitions.
+
+*If Streamlit shows a blank page or reports missing dependencies*, make sure
+that the `pip install` steps completed successfully. When using Docker Compose,
+rebuild the service with `docker compose build dashboard` to refresh the
+image.

--- a/tests/test_dashboard_runtime.py
+++ b/tests/test_dashboard_runtime.py
@@ -1,0 +1,222 @@
+"""Tests for the Streamlit dashboard runtime utilities."""
+from __future__ import annotations
+
+import asyncio
+import json
+import sys
+import time
+from pathlib import Path
+from types import ModuleType
+from typing import Dict, Generator
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+import pytest
+
+# Ensure modules that depend on Streamlit can be imported even if the package
+# is not installed in the test environment. Only the dashboard state helpers
+# rely on ``st.session_state`` which is mimicked by this stub module.
+if "streamlit" not in sys.modules:
+    fake_streamlit = ModuleType("streamlit")
+    fake_streamlit.session_state = {}
+    sys.modules["streamlit"] = fake_streamlit
+
+from conductor.config import FlowConfig, GlobalConfig
+
+from dashboard import state
+from dashboard.services.runtime import OrchestratorRuntime, RunSummary
+
+
+MODULE_PATH = "tests.test_dashboard_runtime"
+
+
+def start_node(node_input):
+    """Increment the incoming payload and forward it."""
+
+    value = node_input.data or 0
+    return {"status": "success", "data": value + 1}
+
+
+def finish_node(node_input):
+    """Double the received payload to signal completion."""
+
+    value = node_input.data or 0
+    return {"status": "success", "data": value * 2}
+
+
+async def slow_node(node_input):
+    """Simulate a long running operation that can be cancelled."""
+
+    await asyncio.sleep(0.2)
+    return {"status": "success", "data": node_input.data}
+
+
+@pytest.fixture
+def runtime() -> Generator[OrchestratorRuntime, None, None]:
+    instance = OrchestratorRuntime()
+    try:
+        yield instance
+    finally:
+        instance.shutdown()
+
+
+@pytest.fixture
+def flow_config_path(tmp_path: Path) -> str:
+    config: Dict[str, object] = {
+        "name": "sample-flow",
+        "start": ["start"],
+        "nodes": [
+            {
+                "id": "start",
+                "callable": f"{MODULE_PATH}:start_node",
+                "transitions": {"success": ["finish"]},
+            },
+            {
+                "id": "finish",
+                "callable": f"{MODULE_PATH}:finish_node",
+            },
+        ],
+    }
+    path = tmp_path / "flow.json"
+    path.write_text(json.dumps(config))
+    return str(path)
+
+
+@pytest.fixture
+def global_config_path(tmp_path: Path) -> str:
+    config = {"env": {"DASHBOARD": "true"}, "metadata": {"source": "test"}}
+    path = tmp_path / "global.json"
+    path.write_text(json.dumps(config))
+    return str(path)
+
+
+def _wait_for_history(runtime: OrchestratorRuntime, run_id: str, *, timeout: float = 1.0) -> RunSummary:
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        snapshot = runtime.runs()
+        for entry in snapshot["history"]:
+            if entry.id == run_id:
+                return entry
+        time.sleep(0.05)
+    raise AssertionError(f"Run {run_id} did not appear in history within {timeout} seconds")
+
+
+def test_register_and_run_flow(runtime: OrchestratorRuntime, flow_config_path: str, global_config_path: str) -> None:
+    name = runtime.register_flow(flow_config_path, global_config=global_config_path)
+
+    assert name == "sample-flow"
+    assert sorted(runtime.list_flows()) == ["sample-flow"]
+
+    flow = runtime.get_flow_config(name)
+    assert isinstance(flow, FlowConfig)
+    assert set(flow.nodes) == {"start", "finish"}
+
+    global_config = runtime.get_global_config(name)
+    assert isinstance(global_config, GlobalConfig)
+    assert global_config.env["DASHBOARD"] == "true"
+
+    summary = runtime.run_flow(
+        name,
+        payload=2,
+        metadata={"request_id": "abc"},
+    )
+
+    assert summary.status == "completed"
+    assert summary.result is not None
+    assert summary.result.flow_name == name
+    assert summary.metadata.get("last_node") == "finish"
+    runs = runtime.runs()
+    assert runs["active"] == []
+    assert runs["history"] == []
+
+
+def test_background_execution_tracking(runtime: OrchestratorRuntime, flow_config_path: str) -> None:
+    runtime.register_flow(flow_config_path)
+
+    pending = runtime.run_flow("sample-flow", payload=1, background=True, metadata={"source": "background"})
+
+    assert pending.status == "running"
+    snapshot = runtime.runs()
+    assert any(run.id == pending.id for run in snapshot["active"])
+
+    # Allow the asynchronous task to complete and propagate to the history queue.
+    entry = _wait_for_history(runtime, pending.id)
+    snapshot = runtime.runs()
+    assert not snapshot["active"]
+    assert entry.status == "completed"
+    assert entry.metadata.get("last_node") == "finish"
+
+    # Once the flow is idle it can be unregistered safely.
+    assert runtime.unregister_flow("sample-flow") is True
+    assert runtime.unregister_flow("sample-flow") is False
+
+
+def test_cancel_background_run(runtime: OrchestratorRuntime) -> None:
+    slow_flow = FlowConfig.from_mapping(
+        {
+            "name": "slow-flow",
+            "start": ["slow"],
+            "nodes": [
+                {
+                    "id": "slow",
+                    "callable": f"{MODULE_PATH}:slow_node",
+                }
+            ],
+        }
+    )
+    runtime.register_flow(slow_flow)
+
+    pending = runtime.run_flow("slow-flow", background=True)
+    assert pending.status == "running"
+
+    # Give the coroutine a chance to start before issuing the cancellation.
+    time.sleep(0.05)
+    assert runtime.cancel_run(pending.id) is True
+
+    entry = _wait_for_history(runtime, pending.id)
+    snapshot = runtime.runs()
+    assert entry.status == "cancelled"
+    assert entry.error == "Run cancelled"
+
+
+def test_session_state_helpers(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake_streamlit = ModuleType("streamlit_stub")
+    fake_streamlit.session_state = {}
+    monkeypatch.setattr(state, "st", fake_streamlit, raising=False)
+
+    created_instances = []
+
+    class DummyRuntime:
+        def __init__(self):
+            self.shutdown_called = False
+            created_instances.append(self)
+
+        def shutdown(self) -> None:
+            self.shutdown_called = True
+
+    monkeypatch.setattr(state, "OrchestratorRuntime", DummyRuntime)
+
+    runtime_first = state.get_runtime()
+    runtime_second = state.get_runtime()
+    assert runtime_first is runtime_second
+    assert len(created_instances) == 1
+
+    cfg = GlobalConfig.from_mapping({"env": {"FOO": "bar"}})
+    state.set_global_config(cfg, path="/tmp/config.json", dirty=False)
+    global_state = state.get_global_config_state()
+    assert global_state["config"] is cfg
+    assert global_state["path"] == "/tmp/config.json"
+    assert global_state["dirty"] is False
+
+    state.mark_global_config_dirty()
+    assert state.get_global_config_state()["dirty"] is True
+    state.mark_global_config_clean()
+    assert state.get_global_config_state()["dirty"] is False
+
+    state.reset_state()
+    assert runtime_first.shutdown_called is True
+    assert state.get_global_config_state()["dirty"] is False
+    assert state.get_runtime() is not runtime_first
+    assert len(created_instances) == 2


### PR DESCRIPTION
## Summary
- add a dedicated Dockerfile and docker-compose service to run the Streamlit dashboard
- document local and container usage of the dashboard and reference it from the README
- add regression tests for the dashboard runtime and state helpers and fix FlowHandle background scheduling

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d502cf5ccc83279576702a6bfa3b50