### PR TITLE
Fix dashboard navigation and runtime stability

### DIFF
--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -29,9 +29,6 @@ def main() -> None:
             st.rerun()
         st.divider()
         selection = st.radio("Navigazione", list(pages.keys()))
-        if st.button("Reset sessione"):
-            state.reset_state()
-            st.rerun()
 
     pages[selection]()
 

--- a/dashboard/components/mermaid.py
+++ b/dashboard/components/mermaid.py
@@ -35,7 +35,6 @@ def mermaid_diagram(
         """,
         height=height,
         scrolling=True,
-        key=key,
     )
     if download:
         download_key = key or f"mermaid-download-{abs(hash(mermaid_source))}"

--- a/dashboard/pages/designer.py
+++ b/dashboard/pages/designer.py
@@ -28,6 +28,20 @@ def render(runtime: OrchestratorRuntime) -> None:
 
     app = sf.App()
 
+    if "flow_builder_current_page" not in st.session_state:
+        st.session_state["flow_builder_current_page"] = _METADATA_PAGE
+        st.session_state["flow_builder_page_args"] = ()
+        st.session_state["flow_builder_page_kwargs"] = {}
+
+    def _remember_page(page: str, *args: Any, **kwargs: Any) -> None:
+        st.session_state["flow_builder_current_page"] = page
+        st.session_state["flow_builder_page_args"] = tuple(args)
+        st.session_state["flow_builder_page_kwargs"] = dict(kwargs)
+
+    def _goto(page: str, *args: Any, **kwargs: Any) -> None:
+        _remember_page(page, *args, **kwargs)
+        app.goto(page, *args, **kwargs)
+
     @app.route(_METADATA_PAGE)
     def metadata_page() -> None:
         st.subheader("Metadati del flow")
@@ -58,7 +72,7 @@ def render(runtime: OrchestratorRuntime) -> None:
             elif not builder_state["start"]:
                 st.error("Indicare almeno un nodo di start.")
             else:
-                app.goto(_NODES_PAGE)
+                _goto(_NODES_PAGE)
 
     @app.route(_NODES_PAGE)
     def nodes_page() -> None:
@@ -188,7 +202,7 @@ def render(runtime: OrchestratorRuntime) -> None:
                     st.success("Nodo eliminato.")
         nav_cols = st.columns(2)
         if nav_cols[0].button("⬅️ Indietro"):
-            app.goto(_METADATA_PAGE)
+            _goto(_METADATA_PAGE)
         if nav_cols[1].button("Avanti ➡️", type="primary"):
             if not nodes:
                 st.error("Definire almeno un nodo.")
@@ -199,7 +213,7 @@ def render(runtime: OrchestratorRuntime) -> None:
                         "I seguenti start node non esistono più: " + ", ".join(missing)
                     )
                 else:
-                    app.goto(_REVIEW_PAGE)
+                    _goto(_REVIEW_PAGE)
 
     @app.route(_REVIEW_PAGE)
     def review_page() -> None:
@@ -208,7 +222,7 @@ def render(runtime: OrchestratorRuntime) -> None:
         if flow_config is None:
             st.error("Completare i passaggi precedenti per generare una configurazione valida.")
             if st.button("⬅️ Torna ai nodi"):
-                app.goto(_NODES_PAGE)
+                _goto(_NODES_PAGE)
             return
         st.success("Configurazione valida.")
         st.markdown(f"**Nome:** {flow_config.name}")
@@ -239,14 +253,20 @@ def render(runtime: OrchestratorRuntime) -> None:
         if reset_col.button("Reset designer"):
             builder_state.clear()
             builder_state.update(_default_state())
-            app.goto(_METADATA_PAGE)
+            _goto(_METADATA_PAGE)
 
         if st.button("⬅️ Torna ai nodi"):
-            app.goto(_NODES_PAGE)
+            _goto(_NODES_PAGE)
 
-    if "flow_builder_initialized" not in st.session_state:
-        app.next(_METADATA_PAGE)
-        st.session_state["flow_builder_initialized"] = True
+    current_page: str = st.session_state.get("flow_builder_current_page", _METADATA_PAGE)
+    current_args = st.session_state.get("flow_builder_page_args", ())
+    current_kwargs = st.session_state.get("flow_builder_page_kwargs", {})
+    if current_page not in app._pages:
+        current_page = _METADATA_PAGE
+        current_args = ()
+        current_kwargs = {}
+        _remember_page(current_page)
+    app.next(current_page, *current_args, **current_kwargs)
 
     app.show()
 
@@ -284,6 +304,9 @@ def _apply_import_if_present(builder_state: Dict[str, Any]) -> None:
             }
         )
         st.success("Flow importato nel designer.")
+        st.session_state["flow_builder_current_page"] = _METADATA_PAGE
+        st.session_state["flow_builder_page_args"] = ()
+        st.session_state["flow_builder_page_kwargs"] = {}
     except Exception as exc:  # pragma: no cover - UI feedback
         st.error(f"Impossibile importare il flow: {exc}")
 
@@ -396,3 +419,9 @@ def _build_flow(state: Dict[str, Any]) -> Optional[FlowConfig]:
 
 
 __all__ = ["render"]
+
+
+if __name__ == "__main__":  # pragma: no cover - streamlit multipage support
+    from dashboard import state
+
+    render(state.get_runtime())

--- a/dashboard/pages/flows.py
+++ b/dashboard/pages/flows.py
@@ -19,30 +19,49 @@ def render(runtime: OrchestratorRuntime) -> None:
     st.header("Gestione flow registrati")
 
     st.subheader("Registrazione di un nuovo flow")
+    st.session_state.setdefault("flow_upload_preview", None)
+    st.session_state.setdefault("flow_upload_filename", None)
+
     col_left, col_right = st.columns(2)
     with col_left:
         uploaded = st.file_uploader(
             "Carica configurazione flow (JSON, YAML, TOML)",
             type=["json", "yaml", "yml", "toml"],
+            key="flow-config-upload",
         )
     with col_right:
         flow_name = st.text_input("Nome da registrare (opzionale)")
         replace = st.checkbox("Sostituisci se il flow esiste già", value=False)
-        auto_load = st.checkbox("Registrazione automatica dopo upload", value=True)
 
-    new_flow: Optional[FlowConfig] = None
     if uploaded is not None:
         try:
-            new_flow = _load_flow_from_upload(uploaded)
-            st.success(f"File caricato: {new_flow.name}")
+            parsed = _load_flow_from_upload(uploaded)
         except Exception as exc:  # pragma: no cover - UI feedback
+            st.session_state["flow_upload_preview"] = None
+            st.session_state["flow_upload_filename"] = None
             st.error(f"Impossibile leggere la configurazione: {exc}")
+        else:
+            st.session_state["flow_upload_preview"] = parsed
+            st.session_state["flow_upload_filename"] = uploaded.name
+            st.success(f"File caricato: {parsed.name}")
 
-    if new_flow and auto_load:
-        _register_flow(runtime, new_flow, flow_name, replace)
-    elif new_flow:
-        if st.button("Registra flow", type="primary"):
-            _register_flow(runtime, new_flow, flow_name, replace)
+    pending_flow: Optional[FlowConfig] = st.session_state.get("flow_upload_preview")
+    if pending_flow is not None:
+        file_name = st.session_state.get("flow_upload_filename")
+        st.info(
+            f"Flow pronto alla registrazione: **{pending_flow.name}**"
+            + (f" (origine `{file_name}`)" if file_name else "")
+        )
+        preview_cols = st.columns(2)
+        if preview_cols[0].button("Registra flow caricato", type="primary"):
+            _register_flow(runtime, pending_flow, flow_name, replace)
+            st.session_state["flow_upload_preview"] = None
+            st.session_state["flow_upload_filename"] = None
+            st.session_state["flow-config-upload"] = None
+        if preview_cols[1].button("Annulla caricamento"):
+            st.session_state["flow_upload_preview"] = None
+            st.session_state["flow_upload_filename"] = None
+            st.session_state["flow-config-upload"] = None
 
     st.divider()
 
@@ -52,14 +71,14 @@ def render(runtime: OrchestratorRuntime) -> None:
         st.info("Nessun flow registrato al momento.")
         return
 
-    for name in flow_names:
+    for idx, name in enumerate(flow_names):
         flow_config = runtime.get_flow_config(name)
         with st.expander(f"{name} ({len(flow_config.nodes)} nodi)"):
             st.markdown(f"**Start:** {', '.join(flow_config.start)}")
             if flow_config.description:
                 st.markdown(flow_config.description)
             _render_nodes_table(flow_config)
-            _flow_actions(runtime, flow_config)
+            _flow_actions(runtime, flow_config, idx)
 
 
 def _register_flow(
@@ -76,15 +95,16 @@ def _register_flow(
     st.success(f"Flow '{registered_name}' registrato correttamente.")
 
 
-def _flow_actions(runtime: OrchestratorRuntime, flow: FlowConfig) -> None:
+def _flow_actions(runtime: OrchestratorRuntime, flow: FlowConfig, index: int) -> None:
+    key_suffix = f"{index}-{abs(hash(flow.name))}"
     payload_text = st.text_area(
         "Payload iniziale (JSON opzionale)",
-        key=f"payload-{flow.name}",
+        key=f"payload-{key_suffix}",
         height=120,
     )
     metadata_text = st.text_area(
         "Metadata aggiuntivi (JSON)",
-        key=f"metadata-{flow.name}",
+        key=f"metadata-{key_suffix}",
         height=120,
     )
 
@@ -92,7 +112,7 @@ def _flow_actions(runtime: OrchestratorRuntime, flow: FlowConfig) -> None:
     metadata, metadata_error = _parse_optional_json(metadata_text)
 
     cols = st.columns(4)
-    if cols[0].button("Esegui (sincrono)", key=f"run-sync-{flow.name}"):
+    if cols[0].button("Esegui (sincrono)", key=f"run-sync-{key_suffix}"):
         if payload_error or metadata_error:
             _show_payload_errors(payload_error, metadata_error)
         else:
@@ -105,7 +125,7 @@ def _flow_actions(runtime: OrchestratorRuntime, flow: FlowConfig) -> None:
             st.success(
                 f"Esecuzione completata con stato {summary.metadata.get('last_status', 'n/a')}"
             )
-    if cols[1].button("Esegui in background", key=f"run-bg-{flow.name}"):
+    if cols[1].button("Esegui in background", key=f"run-bg-{key_suffix}"):
         if payload_error or metadata_error:
             _show_payload_errors(payload_error, metadata_error)
         else:
@@ -118,10 +138,10 @@ def _flow_actions(runtime: OrchestratorRuntime, flow: FlowConfig) -> None:
             st.info(
                 f"Esecuzione avviata (run-id {summary.id}). Monitora nella sezione Monitoraggio."
             )
-    if cols[2].button("Apri nel Flow Designer", key=f"designer-{flow.name}"):
+    if cols[2].button("Apri nel Flow Designer", key=f"designer-{key_suffix}"):
         st.session_state["flow_builder_import"] = flow_config_to_dict(flow)
         st.success("Flow caricato nel designer. Apri la pagina 'Flow Designer'.")
-    if cols[3].button("Deregistra", key=f"unregister-{flow.name}"):
+    if cols[3].button("Deregistra", key=f"unregister-{key_suffix}"):
         try:
             runtime.unregister_flow(flow.name)
         except Exception as exc:  # pragma: no cover - UI feedback
@@ -182,3 +202,9 @@ def _show_payload_errors(*errors: Optional[str]) -> None:
 
 
 __all__ = ["render"]
+
+
+if __name__ == "__main__":  # pragma: no cover - streamlit multipage support
+    from dashboard import state
+
+    render(state.get_runtime())

--- a/dashboard/pages/overview.py
+++ b/dashboard/pages/overview.py
@@ -112,3 +112,9 @@ def _render_history_entry(runtime: OrchestratorRuntime, summary: RunSummary) -> 
 
 
 __all__ = ["render"]
+
+
+if __name__ == "__main__":  # pragma: no cover - streamlit multipage support
+    from dashboard import state
+
+    render(state.get_runtime())

--- a/dashboard/pages/schedules.py
+++ b/dashboard/pages/schedules.py
@@ -132,3 +132,9 @@ def _show_errors(*errors: Optional[str]) -> None:
 
 
 __all__ = ["render"]
+
+
+if __name__ == "__main__":  # pragma: no cover - streamlit multipage support
+    from dashboard import state
+
+    render(state.get_runtime())

--- a/dashboard/pages/settings.py
+++ b/dashboard/pages/settings.py
@@ -96,27 +96,31 @@ def _editor(config: GlobalConfig) -> None:
         mapping: Dict[str, Any] = {}
         errors: List[str] = []
 
-        general_data, general_errors = _general_section(config)
+        with general_tab:
+            general_data, general_errors = _general_section(config)
         mapping.update(general_data)
         errors.extend(general_errors)
 
-        resources_data, resources_errors = _locations_section(
-            config.resource_locations,
-            table_key="resource-locations",
-            empty_label="Nessuna resource location definita.",
-        )
+        with resources_tab:
+            resources_data, resources_errors = _locations_section(
+                config.resource_locations,
+                table_key="resource-locations",
+                empty_label="Nessuna resource location definita.",
+            )
         mapping["resource_locations"] = resources_data
         errors.extend(resources_errors)
 
-        code_data, code_errors = _locations_section(
-            config.code_locations,
-            table_key="code-locations",
-            empty_label="Nessuna code location definita.",
-        )
+        with code_tab:
+            code_data, code_errors = _locations_section(
+                config.code_locations,
+                table_key="code-locations",
+                empty_label="Nessuna code location definita.",
+            )
         mapping["code_locations"] = code_data
         errors.extend(code_errors)
 
-        logging_data, logging_errors = _logging_section(config)
+        with logging_tab:
+            logging_data, logging_errors = _logging_section(config)
         if logging_data is not None:
             mapping["remote_logging"] = logging_data
         errors.extend(logging_errors)
@@ -363,3 +367,7 @@ def _normalize_editor_rows(data) -> List[Dict[str, Any]]:
 
 
 __all__ = ["render"]
+
+
+if __name__ == "__main__":  # pragma: no cover - streamlit multipage support
+    render()

--- a/dashboard/services/runtime.py
+++ b/dashboard/services/runtime.py
@@ -61,7 +61,7 @@ class OrchestratorRuntime:
         self._max_history = max_history
         self._active_runs: Dict[str, _RunEntry] = {}
         self._history: List[RunSummary] = []
-        self._completed: "queue.Queue[RunSummary]" = queue.Queue()
+        self._completed: "queue.Queue[tuple[str, RunSummary]]" = queue.Queue()
         self._closed = False
         self._thread.start()
         self._ready.wait()
@@ -198,8 +198,8 @@ class OrchestratorRuntime:
     def runs(self) -> Dict[str, List[RunSummary]]:
         """Return snapshots of active and completed runs."""
 
-        self._drain_completed()
         active = self._run_coroutine(self._snapshot_active())
+        self._drain_completed()
         return {"active": active, "history": list(self._history)}
 
     def shutdown(self) -> None:
@@ -278,7 +278,6 @@ class OrchestratorRuntime:
             self._active_runs[run_id] = entry
 
             def _done_callback(fut: asyncio.Future[FlowExecution]) -> None:
-                self._active_runs.pop(run_id, None)
                 finished_at = datetime.now(timezone.utc)
                 try:
                     execution = fut.result()
@@ -315,7 +314,7 @@ class OrchestratorRuntime:
                         metadata=dict(entry.metadata),
                         error=str(exc),
                     )
-                self._completed.put(summary)
+                self._completed.put((run_id, summary))
 
             task.add_done_callback(_done_callback)
             return RunSummary(
@@ -401,7 +400,8 @@ class OrchestratorRuntime:
     def _drain_completed(self) -> None:
         updated = False
         while not self._completed.empty():
-            summary = self._completed.get()
+            run_id, summary = self._completed.get()
+            self._active_runs.pop(run_id, None)
             self._history.insert(0, summary)
             if len(self._history) > self._max_history:
                 self._history = self._history[: self._max_history]


### PR DESCRIPTION
## Summary
- remove the session reset entry from the sidebar navigation and keep the metric panel intact
- stabilise the Flow Designer by persisting the current step, resetting imports correctly and avoiding duplicate widget keys
- require manual confirmation when uploading flows, wire multi-page entries to the main app, and ensure the mermaid component works with current Streamlit
- wrap the global settings editor sections inside their tabs and harden background run tracking in the runtime service

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68d50d7ecf34832786f4be38d7c0f486