### PR TITLE
Improve dashboard runtime feedback and compose defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,25 @@ docker compose up dashboard
 
 The application relies on the same workspace files, so any flow or configuration
 changes performed through the dashboard remain local to the repository checkout.
+The dashboard automatically loads the global configuration referenced by the
+`CONDUCTOR_GLOBAL_CONFIG` environment variable (set to
+`/etc/conductor/global.json` in the Compose file). Adjust the mount or variable
+if you want to point the UI at a different baseline configuration.
+
+The Compose file also exposes an optional `conductor` service under the `cli`
+profile. It keeps an idle container around so you can execute CLI commands
+without triggering a flow automatically:
+
+```bash
+# Launch the dashboard and the helper CLI container
+docker compose --profile cli up dashboard
+
+# Run commands on demand
+docker compose run --rm conductor run --flow flows://order-routing.json
+```
+
+If you do not need the helper container simply omit the profile and only the
+dashboard will start.
 
 ## Configuration overview
 

--- a/conductor/logging_utils.py
+++ b/conductor/logging_utils.py
@@ -13,6 +13,9 @@ from .config import GlobalConfig, RemoteLoggingConfig
 
 LOG_FORMAT = "%(asctime)s %(levelname)s [%(name)s] %(message)s"
 
+_DEFAULT_HANDLER_ATTR = "_conductor_default_handler"
+_REMOTE_HANDLER_ATTR = "_conductor_remote_handler"
+
 
 class RemoteLogHandler(Handler):
     """Send log records to a remote HTTP endpoint."""
@@ -50,15 +53,31 @@ def configure_logging(config: Optional[GlobalConfig], level: int = logging.INFO)
 
     logger = logging.getLogger("conductor")
     logger.setLevel(level)
-    logger.handlers = []
 
-    stream_handler = logging.StreamHandler()
-    stream_handler.setFormatter(logging.Formatter(LOG_FORMAT))
-    logger.addHandler(stream_handler)
+    formatter = logging.Formatter(LOG_FORMAT)
+
+    default_handler: Optional[logging.Handler] = None
+    for handler in logger.handlers:
+        if getattr(handler, _DEFAULT_HANDLER_ATTR, False):
+            default_handler = handler
+            break
+
+    if default_handler is None:
+        default_handler = logging.StreamHandler()
+        setattr(default_handler, _DEFAULT_HANDLER_ATTR, True)
+        logger.addHandler(default_handler)
+
+    default_handler.setFormatter(formatter)
+
+    # Remove any previously configured remote handlers before installing a new one.
+    for handler in list(logger.handlers):
+        if getattr(handler, _REMOTE_HANDLER_ATTR, False):
+            logger.removeHandler(handler)
 
     if config and config.remote_logging and config.remote_logging.enabled:
         remote_handler = RemoteLogHandler(config.remote_logging)
-        remote_handler.setFormatter(logging.Formatter(LOG_FORMAT))
+        remote_handler.setFormatter(formatter)
+        setattr(remote_handler, _REMOTE_HANDLER_ATTR, True)
         logger.addHandler(remote_handler)
 
     return logger

--- a/dashboard/pages/operations.py
+++ b/dashboard/pages/operations.py
@@ -244,8 +244,13 @@ def _render_manual_runs(runtime: OrchestratorRuntime, flows: List[str]) -> None:
             if background:
                 st.info(f"Flow '{flow_name}' avviato in background (run-id {summary.id}).")
             else:
-                status = summary.metadata.get("last_status", summary.status)
-                st.success(f"Flow '{flow_name}' completato con stato {status}.")
+                status = (summary.status or "").lower()
+                if status == "error":
+                    details = summary.error or summary.metadata.get("last_status", "error")
+                    st.error(f"Flow '{flow_name}' terminato con errore: {details}.")
+                else:
+                    display_status = summary.metadata.get("last_status", summary.status)
+                    st.success(f"Flow '{flow_name}' completato con stato {display_status}.")
 
 
 

--- a/dashboard/services/runtime.py
+++ b/dashboard/services/runtime.py
@@ -159,7 +159,7 @@ class OrchestratorRuntime:
         execution = self._run_coroutine(
             self._run_flow_once(name, payload, metadata, schedule_id)
         )
-        return self._summarise_execution(execution, status="completed")
+        return self._summarise_execution(execution)
 
     def schedule_flow(
         self,
@@ -309,7 +309,6 @@ class OrchestratorRuntime:
                     execution = fut.result()
                     summary = self._summarise_execution(
                         execution,
-                        status="completed",
                         run_id=run_id,
                     )
                 except asyncio.CancelledError:
@@ -376,8 +375,8 @@ class OrchestratorRuntime:
         self,
         execution: FlowExecution,
         *,
-        status: str,
         run_id: Optional[str] = None,
+        default_status: str = "completed",
     ) -> RunSummary:
         finished_at = execution.finished_at
         started_at = execution.started_at
@@ -386,10 +385,35 @@ class OrchestratorRuntime:
             duration = (finished_at - started_at).total_seconds()
         payload_preview = execution.payload
         metadata = dict(execution.metadata)
+        last_output = None
         if execution.results:
             last = execution.results[-1]
+            last_output = last.output
             metadata.setdefault("last_status", last.output.status)
             metadata.setdefault("last_node", last.node_id)
+        computed_status = metadata.get("last_status")
+        if not computed_status and last_output is not None:
+            computed_status = last_output.status
+        normalized = str(computed_status or "").lower()
+        status = default_status
+        if normalized in {"error", "failed", "failure"}:
+            status = "error"
+        elif normalized in {"cancelled", "canceled"}:
+            status = "cancelled"
+        error_message = metadata.get("error")
+        if (
+            status == "error"
+            and error_message is None
+            and last_output is not None
+            and isinstance(getattr(last_output, "status", ""), str)
+        ):
+            data = getattr(last_output, "data", None)
+            if isinstance(data, dict):
+                error_message = str(data.get("error") or data)
+            elif data not in (None, ""):
+                error_message = str(data)
+            else:
+                error_message = "Flow execution ended with status 'error'."
         return RunSummary(
             id=run_id or uuid.uuid4().hex,
             flow_name=execution.flow_name,
@@ -400,6 +424,7 @@ class OrchestratorRuntime:
             schedule_id=execution.schedule_id,
             payload_preview=payload_preview,
             metadata=metadata,
+            error=error_message,
             result=execution,
         )
 

--- a/dashboard/state.py
+++ b/dashboard/state.py
@@ -1,11 +1,12 @@
 ﻿"""Session state helpers for the Streamlit dashboard."""
 from __future__ import annotations
 
+import os
 from typing import Any, Dict, Optional
 
 import streamlit as st
 
-from conductor.config import GlobalConfig
+from conductor.config import GlobalConfig, load_global_config
 
 from dashboard.services.runtime import OrchestratorRuntime
 
@@ -27,8 +28,26 @@ def get_global_config_state() -> Dict[str, Any]:
             "config": GlobalConfig.from_mapping({}),
             "path": None,
             "dirty": False,
+            "_initialised": False,
         },
     )
+    if not state.get("_initialised"):
+        state["_initialised"] = True
+        env_path = os.environ.get("CONDUCTOR_GLOBAL_CONFIG")
+        if env_path:
+            try:
+                config = load_global_config(env_path)
+            except Exception as exc:  # pragma: no cover - configuration feedback
+                state["_load_error"] = str(exc)
+                state["_load_source"] = env_path
+            else:
+                state["config"] = config
+                state["path"] = env_path
+                state["dirty"] = False
+    if state.get("_load_error") and not state.get("_load_error_reported"):
+        source = state.get("_load_source", "CONDUCTOR_GLOBAL_CONFIG")
+        st.warning(f"Impossibile caricare la global config '{source}': {state['_load_error']}")
+        state["_load_error_reported"] = True
     return state
 
 

--- a/deploy/docker-compose.yaml
+++ b/deploy/docker-compose.yaml
@@ -1,7 +1,21 @@
 version: "3.9"
 
 services:
+  dashboard:
+    build:
+      context: ..
+      dockerfile: deploy/dashboard.Dockerfile
+    restart: unless-stopped
+    environment:
+      CONDUCTOR_GLOBAL_CONFIG: /etc/conductor/global.json
+      STREAMLIT_SERVER_PORT: 8501
+    ports:
+      - "8503:8501"
+    volumes:
+      - ./config:/etc/conductor:ro
+
   conductor:
+    profiles: ["cli"]
     build:
       context: ..
       dockerfile: deploy/conductor.Dockerfile
@@ -15,26 +29,8 @@ services:
       - ./config:/etc/conductor:ro
       - conductor-cache:/root/.conductor
     command:
-      - run
-      - --flow
-      - flows://order-routing.json
-      - --payload-file
-      - payloads://latest.json
-
-  dashboard:
-    build:
-      context: ..
-      dockerfile: deploy/dashboard.Dockerfile
-    restart: unless-stopped
-    environment:
-      CONDUCTOR_GLOBAL_CONFIG: /etc/conductor/global.json
-      STREAMLIT_SERVER_PORT: 8501
-    ports:
-      - "8503:8501"
-    volumes:
-      - ./config:/etc/conductor:ro
-    depends_on:
-      - conductor
+      - sleep
+      - "infinity"
 
 volumes:
   conductor-cache:

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -65,7 +65,22 @@ dashboard.
 
 The Compose service mounts the `deploy/config` directory into the container so
 you can share configuration files between the dashboard and the core Conductor
-service. Adjust the volume mappings if your flows live elsewhere.
+service. Adjust the volume mappings if your flows live elsewhere. The dashboard
+automatically loads the configuration file pointed to by the
+`CONDUCTOR_GLOBAL_CONFIG` environment variable. The default Compose
+configuration sets this to `/etc/conductor/global.json`, so edits performed in
+the dashboard start from that baseline.
+
+An optional `conductor` service is available under the `cli` profile. It keeps a
+shell-friendly container around without executing any flow on startup, which is
+useful if you want to run CLI commands alongside the dashboard:
+
+```bash
+docker compose --profile cli up dashboard
+docker compose run --rm conductor run --flow flows://your-flow.json
+```
+
+If you do not enable the profile only the dashboard container will be started.
 
 ### Customising the service
 
@@ -74,7 +89,8 @@ required:
 
 - `STREAMLIT_SERVER_PORT` - change the HTTP port exposed by Streamlit.
 - `CONDUCTOR_GLOBAL_CONFIG` - specify the default global configuration file to
-  load.
+  load. The dashboard reads this value on startup to pre-populate the
+  application settings.
 
 For production deployments consider publishing the container image to a registry
 and referencing it in the Compose file instead of building it locally.


### PR DESCRIPTION
## Summary
- ensure the dashboard loads the global configuration from CONDUCTOR_GLOBAL_CONFIG and warn when it cannot
- keep the dashboard log handler installed when CLI logging is reconfigured
- surface flow errors in the UI, improve manual run feedback, and make the Docker Compose setup dashboard-first with updated docs

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d548c45f5c8327a1b75b28458960d7