### PR TITLE
Handle dashboard config parsing issues and expose container logs

### DIFF
--- a/conductor/config.py
+++ b/conductor/config.py
@@ -141,12 +141,24 @@ def _parse_repository_locations(raw: Any, section_name: str) -> Dict[str, Reposi
 class GlobalConfig:
     """Server-level runtime configuration shared across flows."""
 
-    remote_logging: Optional[RemoteLoggingConfig] = None
-    env: Dict[str, str] = field(default_factory=dict)
-    max_concurrency: Optional[int] = None
-    process_pool_size: Optional[int] = None
-    shared_state: Dict[str, Any] = field(default_factory=dict)
-    extra: Dict[str, Any] = field(default_factory=dict)
+    def __init__(
+        self,
+        *,
+        env: Optional[Mapping[str, Any]] = None,
+        shared_state: Optional[Mapping[str, Any]] = None,
+        max_concurrency: Optional[int] = None,
+        process_pool_size: Optional[int] = None,
+        dependencies: Optional[Iterable[str]] = None,
+        remote_logging: Optional[RemoteLoggingConfig] = None,
+        extra: Optional[Mapping[str, Any]] = None,
+    ) -> None:
+        self.env: Dict[str, Any] = dict(env or {})
+        self.shared_state: Dict[str, Any] = dict(shared_state or {})
+        self.max_concurrency = max_concurrency
+        self.process_pool_size = process_pool_size
+        self.dependencies = list(dependencies or [])
+        self.remote_logging = remote_logging
+        self.extra: Dict[str, Any] = dict(extra or {})
 
     @classmethod
     def from_mapping(cls, data: Mapping[str, Any] | None) -> "GlobalConfig":
@@ -163,6 +175,19 @@ class GlobalConfig:
         max_concurrency = data.get("max_concurrency") or data.get("maxConcurrency")
         process_pool_size = data.get("process_pool_size") or data.get("processPoolSize")
         shared_state = dict(data.get("shared_state") or data.get("sharedState") or {})
+        raw_dependencies = data.get("dependencies") or data.get("packages")
+        dependencies: List[str] = []
+        if raw_dependencies:
+            if isinstance(raw_dependencies, (list, tuple, set)):
+                dependencies = [str(item).strip() for item in raw_dependencies if str(item).strip()]
+            elif isinstance(raw_dependencies, str):
+                dependencies = [
+                    line.strip()
+                    for line in raw_dependencies.replace(",", "\n").splitlines()
+                    if line.strip()
+                ]
+            else:
+                raise TypeError("Global config 'dependencies' must be a sequence or string.")
 
         known_keys = {
             "remote_logging",
@@ -175,6 +200,8 @@ class GlobalConfig:
             "processPoolSize",
             "shared_state",
             "sharedState",
+            "dependencies",
+            "packages",
         }
         extra = {k: v for k, v in data.items() if k not in known_keys}
 
@@ -184,6 +211,7 @@ class GlobalConfig:
             max_concurrency=int(max_concurrency) if max_concurrency is not None else None,
             process_pool_size=int(process_pool_size) if process_pool_size is not None else None,
             shared_state=shared_state,
+            dependencies=dependencies,
             extra=extra,
         )
 

--- a/dashboard/pages/operations.py
+++ b/dashboard/pages/operations.py
@@ -261,7 +261,7 @@ def _render_manual_runs(runtime: OrchestratorRuntime, flows: List[str]) -> None:
 
 def _render_logs(runtime: OrchestratorRuntime) -> None:
     st.subheader("Log runtime")
-    cols = st.columns([3, 1])
+    cols = st.columns([2, 1, 1])
     level_options = ["ALL", "DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"]
     selected = cols[0].selectbox(
         "Livello minimo",
@@ -269,7 +269,15 @@ def _render_logs(runtime: OrchestratorRuntime) -> None:
         index=2,
         key="logs-min-level",
     )
-    if cols[1].button("Svuota log", key="logs-clear"):
+    tail_lines = cols[1].number_input(
+        "Righe per container",
+        min_value=10,
+        max_value=2000,
+        value=200,
+        step=10,
+        key="logs-tail-lines",
+    )
+    if cols[2].button("Svuota log", key="logs-clear"):
         runtime.clear_logs()
         st.success("Log eliminati.")
 
@@ -289,6 +297,22 @@ def _render_logs(runtime: OrchestratorRuntime) -> None:
         for entry in entries
     ]
     st.dataframe(rows, use_container_width=True, hide_index=True)
+
+    st.subheader("Log container Docker")
+    container_logs = runtime.container_logs(tail=int(tail_lines))
+    if not container_logs:
+        st.info("Nessun container configurato per la raccolta dei log.")
+        return
+
+    for snapshot in container_logs:
+        label = f"{snapshot.name}"
+        with st.expander(label, expanded=snapshot.error is not None):
+            if snapshot.error:
+                st.warning(f"Impossibile leggere i log: {snapshot.error}")
+            if snapshot.content:
+                st.code(snapshot.content, language="log")
+            elif not snapshot.error:
+                st.info("Nessun log disponibile per il container specificato.")
 
 # ---------------------------------------------------------------------------
 # Helpers

--- a/dashboard/pages/settings.py
+++ b/dashboard/pages/settings.py
@@ -140,6 +140,12 @@ def _general_section(config: GlobalConfig) -> Tuple[Dict[str, Any], List[str]]:
         value=json.dumps(config.shared_state, ensure_ascii=False, indent=2),
         height=140,
     )
+    dependencies_text = st.text_area(
+        "Dipendenze Python (una per riga o JSON)",
+        value="\n".join(config.dependencies),
+        help="Specificare le librerie che il runtime deve installare all'avvio.",
+        height=120,
+    )
 
     env, env_error = _safe_json_dict(env_text, "env", config.env)
     if env_error:
@@ -147,12 +153,16 @@ def _general_section(config: GlobalConfig) -> Tuple[Dict[str, Any], List[str]]:
     shared_state, state_error = _safe_json_dict(shared_state_text, "shared_state", config.shared_state)
     if state_error:
         errors.append(state_error)
+    dependencies, deps_error = _parse_dependencies(dependencies_text, config.dependencies)
+    if deps_error:
+        errors.append(deps_error)
 
     mapping: Dict[str, Any] = {
         "env": env,
         "shared_state": shared_state,
         "max_concurrency": max_concurrency or None,
         "process_pool_size": process_pool or None,
+        "dependencies": dependencies,
     }
     return mapping, errors
 
@@ -218,6 +228,36 @@ def _save_controls(config: GlobalConfig) -> None:
                 st.error(f"Salvataggio fallito: {exc}")
             else:
                 mark_global_config_clean()
+
+
+def _safe_json_dict(text: str, field_name: str, fallback: Dict[str, Any]) -> Tuple[Dict[str, Any], Optional[str]]:
+    stripped = text.strip()
+    if not stripped:
+        return {}, None
+    try:
+        value = json.loads(stripped)
+    except json.JSONDecodeError as exc:
+        return dict(fallback), f"Il campo '{field_name}' contiene JSON non valido: {exc}"
+    if not isinstance(value, dict):
+        return dict(fallback), f"Il campo '{field_name}' deve essere un oggetto JSON."
+    return value, None
+
+
+def _parse_dependencies(text: str, fallback: List[str]) -> Tuple[List[str], Optional[str]]:
+    stripped = text.strip()
+    if not stripped:
+        return [], None
+    try:
+        data = json.loads(stripped)
+    except json.JSONDecodeError:
+        entries = [line.strip() for line in stripped.splitlines() if line.strip()]
+        return entries, None
+    if isinstance(data, (list, tuple, set)):
+        return [str(item).strip() for item in data if str(item).strip()], None
+    if isinstance(data, str):
+        entries = [part.strip() for part in data.replace(",", "\n").splitlines() if part.strip()]
+        return entries, None
+    return list(fallback), "Il campo 'dependencies' deve essere un array JSON, una stringa o righe separate."
                 st.success(f"Configurazione salvata in {path}")
 
 

--- a/dashboard/services/container_logs.py
+++ b/dashboard/services/container_logs.py
@@ -1,0 +1,85 @@
+"""Helpers to collect container logs for display inside the dashboard."""
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from dataclasses import dataclass
+from typing import List, Optional, Sequence
+
+
+_DEFAULT_CONTAINERS = ("deploy-dashboard-1", "deploy-conductor-1")
+
+
+@dataclass
+class ContainerLogSnapshot:
+    """Result of fetching the tail of a container log."""
+
+    name: str
+    content: str
+    error: Optional[str] = None
+
+    @property
+    def lines(self) -> List[str]:
+        if not self.content:
+            return []
+        return self.content.splitlines()
+
+
+def _resolve_container_names(names: Optional[Sequence[str]]) -> List[str]:
+    if names:
+        return [name for name in names if name]
+    env_value = os.environ.get("CONDUCTOR_DASHBOARD_LOG_CONTAINERS")
+    if env_value:
+        items = [item.strip() for item in env_value.split(",") if item.strip()]
+        if items:
+            return items
+    return list(_DEFAULT_CONTAINERS)
+
+
+def _resolve_docker_command() -> Optional[str]:
+    override = os.environ.get("CONDUCTOR_DASHBOARD_DOCKER_BIN")
+    if override:
+        return override
+    return shutil.which("docker")
+
+
+def collect_container_logs(*, names: Optional[Sequence[str]] = None, tail: int = 200) -> List[ContainerLogSnapshot]:
+    """Return log snippets for the configured containers.
+
+    The function is resilient to missing Docker installations or containers.
+    """
+
+    resolved_names = _resolve_container_names(names)
+    if not resolved_names:
+        return []
+    docker_cmd = _resolve_docker_command()
+    if not docker_cmd:
+        return [
+            ContainerLogSnapshot(name=name, content="", error="Docker CLI non disponibile nel container dashboard.")
+            for name in resolved_names
+        ]
+
+    snapshots: List[ContainerLogSnapshot] = []
+    for name in resolved_names:
+        args = [docker_cmd, "logs", "--tail", str(max(1, tail)), name]
+        try:
+            result = subprocess.run(
+                args,
+                capture_output=True,
+                text=True,
+                check=False,
+                timeout=10,
+            )
+        except Exception as exc:  # pragma: no cover - defensive runtime safeguard
+            snapshots.append(ContainerLogSnapshot(name=name, content="", error=str(exc)))
+            continue
+        if result.returncode != 0:
+            error_message = result.stderr.strip() or f"Exit code {result.returncode}"
+            snapshots.append(ContainerLogSnapshot(name=name, content=result.stdout.strip(), error=error_message))
+        else:
+            snapshots.append(ContainerLogSnapshot(name=name, content=result.stdout.strip()))
+    return snapshots
+
+
+__all__ = ["ContainerLogSnapshot", "collect_container_logs"]

--- a/dashboard/services/logs.py
+++ b/dashboard/services/logs.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 import logging
 import threading
-import time
 import uuid
 from collections import deque
 from dataclasses import dataclass

--- a/dashboard/services/runtime.py
+++ b/dashboard/services/runtime.py
@@ -19,6 +19,10 @@ from conductor.config import (
 from conductor.orchestrator import FlowExecution, FlowOrchestrator, ScheduledFlow
 
 
+from dashboard.services.container_logs import (
+    ContainerLogSnapshot,
+    collect_container_logs,
+)
 from dashboard.services.logs import LogEntry, install_dashboard_log_handler
 
 @dataclass
@@ -224,6 +228,11 @@ class OrchestratorRuntime:
         """Return captured log entries, optionally filtered by level name."""
 
         return self._log_buffer.snapshot(level=minimum_level)
+
+    def container_logs(self, *, tail: int = 200) -> List[ContainerLogSnapshot]:
+        """Collect recent log lines from the configured Docker containers."""
+
+        return collect_container_logs(tail=tail)
 
     def clear_logs(self) -> None:
         """Clear the in-memory log buffer."""

--- a/dashboard/services/serialization.py
+++ b/dashboard/services/serialization.py
@@ -72,6 +72,8 @@ def global_config_to_dict(config: GlobalConfig) -> Dict[str, Any]:
     }
     if config.remote_logging:
         data["remote_logging"] = _remote_logging_to_dict(config.remote_logging)
+    if config.dependencies:
+        data["dependencies"] = list(config.dependencies)
     if config.extra:
         data.update(config.extra)
     return data

--- a/tests/test_dashboard_runtime.py
+++ b/tests/test_dashboard_runtime.py
@@ -32,6 +32,8 @@ if "streamlit" not in sys.modules:
     sys.modules["streamlit"] = fake_streamlit
 
 from conductor.config import FlowConfig, FlowDeployment, FlowRuntimeConfig, GlobalConfig, load_flow_config
+from dashboard.services import container_logs as container_logs_module
+from dashboard.services.serialization import global_config_to_dict
 
 from dashboard import state
 from dashboard.services import deployments
@@ -60,6 +62,17 @@ async def slow_node(node_input):
 
     await asyncio.sleep(0.2)
     return {"status": "success", "data": node_input.data}
+
+
+def test_global_config_dependencies_parsing() -> None:
+    config = GlobalConfig.from_mapping({"dependencies": ["pkg-a", "pkg-b"]})
+    assert config.dependencies == ["pkg-a", "pkg-b"]
+
+    alt = GlobalConfig.from_mapping({"packages": "pkg-c, pkg-d"})
+    assert alt.dependencies == ["pkg-c", "pkg-d"]
+
+    dumped = global_config_to_dict(config)
+    assert dumped["dependencies"] == ["pkg-a", "pkg-b"]
 
 
 @pytest.fixture
@@ -186,6 +199,17 @@ def test_background_execution_tracking(runtime: OrchestratorRuntime, flow_config
     # Once the flow is idle it can be unregistered safely.
     assert runtime.unregister_flow("sample-flow") is True
     assert runtime.unregister_flow("sample-flow") is False
+
+
+def test_runtime_container_logs_handles_missing_docker(monkeypatch, runtime: OrchestratorRuntime) -> None:
+    monkeypatch.setenv("CONDUCTOR_DASHBOARD_LOG_CONTAINERS", "custom-container")
+    monkeypatch.setattr(container_logs_module, "_resolve_docker_command", lambda: None)
+
+    snapshots = runtime.container_logs(tail=25)
+
+    assert snapshots
+    assert snapshots[0].name == "custom-container"
+    assert snapshots[0].error
 
 
 def test_cancel_background_run(runtime: OrchestratorRuntime) -> None:


### PR DESCRIPTION
## Summary
- add first-class support for dependency lists in the global config model and editor, including safer JSON parsing helpers
- surface Docker container logs in the dashboard alongside in-memory runtime logs and provide resilient collection utilities
- extend dashboard runtime tests to cover dependency serialisation and container log collection fallbacks

## Testing
- pytest tests/test_dashboard_runtime.py

------
https://chatgpt.com/codex/tasks/task_e_68d66d4cd3748327b6dd31e7a99633ba