### PR TITLE
Improve dashboard runtime tracking and auto refresh

### DIFF
--- a/conductor/orchestrator/__init__.py
+++ b/conductor/orchestrator/__init__.py
@@ -78,6 +78,7 @@ class CronSchedule:
 class FlowExecution:
     """Result of a single flow execution triggered by the orchestrator."""
 
+    id: str
     flow_name: str
     results: List[FlowResult]
     payload: Any = None
@@ -159,8 +160,19 @@ class FlowHandle:
     def global_config(self) -> GlobalConfig:
         return self._registration.deployment.global_config
 
-    async def run(self, payload: Any = None, *, metadata: Optional[Dict[str, Any]] = None) -> FlowExecution:
-        return await self._orchestrator.run_flow(self.name, payload=payload, metadata=metadata)
+    async def run(
+        self,
+        payload: Any = None,
+        *,
+        metadata: Optional[Dict[str, Any]] = None,
+        run_id: Optional[str] = None,
+    ) -> FlowExecution:
+        return await self._orchestrator.run_flow(
+            self.name,
+            payload=payload,
+            metadata=metadata,
+            run_id=run_id,
+        )
 
     def run_in_background(
         self,
@@ -168,12 +180,14 @@ class FlowHandle:
         *,
         metadata: Optional[Dict[str, Any]] = None,
         schedule_id: Optional[str] = None,
+        run_id: Optional[str] = None,
     ) -> asyncio.Task[FlowExecution]:
         return self._orchestrator.run_flow_in_background(
             self.name,
             payload=payload,
             metadata=metadata,
             schedule_id=schedule_id,
+            run_id=run_id,
         )
 
     def schedule(
@@ -199,10 +213,35 @@ class FlowHandle:
         )
 
 
+ExecutionStartCallback = Callable[
+    [
+        str,
+        str,
+        Optional[asyncio.Task["FlowExecution"]],
+        Any,
+        Dict[str, Any],
+        Optional[str],
+        datetime,
+    ],
+    None,
+]
+ExecutionSuccessCallback = Callable[["FlowExecution"], None]
+ExecutionErrorCallback = Callable[[str, str, Any, Dict[str, Any], Optional[str], datetime, datetime, BaseException], None]
+ExecutionCancelledCallback = Callable[[str, str, Any, Dict[str, Any], Optional[str], datetime, datetime], None]
+
+
 class FlowOrchestrator:
     """Register, execute, and schedule flows backed by :class:`FlowExecutor`."""
 
-    def __init__(self, *, logger: Optional[logging.Logger] = None):
+    def __init__(
+        self,
+        *,
+        logger: Optional[logging.Logger] = None,
+        on_execution_start: Optional[ExecutionStartCallback] = None,
+        on_execution_success: Optional[ExecutionSuccessCallback] = None,
+        on_execution_error: Optional[ExecutionErrorCallback] = None,
+        on_execution_cancelled: Optional[ExecutionCancelledCallback] = None,
+    ):
         self.logger = logger or logging.getLogger("conductor.orchestrator")
         self._flows: Dict[str, FlowRegistration] = {}
         self._handles: Dict[str, FlowHandle] = {}
@@ -212,6 +251,10 @@ class FlowOrchestrator:
         self._scheduler_task: Optional[asyncio.Task[None]] = None
         self._wake_event: Optional[asyncio.Event] = None
         self._running_scheduler = False
+        self._on_execution_start = on_execution_start
+        self._on_execution_success = on_execution_success
+        self._on_execution_error = on_execution_error
+        self._on_execution_cancelled = on_execution_cancelled
 
     # ------------------------------------------------------------------
     # Flow registration
@@ -283,9 +326,16 @@ class FlowOrchestrator:
         *,
         metadata: Optional[Dict[str, Any]] = None,
         schedule_id: Optional[str] = None,
+        run_id: Optional[str] = None,
     ) -> FlowExecution:
         registration = self._get_registration(name)
-        return await self._execute_flow(registration, payload, metadata=metadata, schedule_id=schedule_id)
+        return await self._execute_flow(
+            registration,
+            payload,
+            metadata=metadata,
+            schedule_id=schedule_id,
+            run_id=run_id,
+        )
 
     def run_flow_in_background(
         self,
@@ -294,11 +344,18 @@ class FlowOrchestrator:
         *,
         metadata: Optional[Dict[str, Any]] = None,
         schedule_id: Optional[str] = None,
+        run_id: Optional[str] = None,
     ) -> asyncio.Task[FlowExecution]:
         registration = self._get_registration(name)
         loop = asyncio.get_running_loop()
         task = loop.create_task(
-            self._execute_flow(registration, payload, metadata=metadata, schedule_id=schedule_id)
+            self._execute_flow(
+                registration,
+                payload,
+                metadata=metadata,
+                schedule_id=schedule_id,
+                run_id=run_id,
+            )
         )
         self._track_task(registration, task)
         return task
@@ -309,8 +366,11 @@ class FlowOrchestrator:
         payload: Any = None,
         *,
         metadata: Optional[Dict[str, Any]] = None,
+        run_id: Optional[str] = None,
     ) -> FlowExecution:
-        return asyncio.run(self.run_flow(name, payload=payload, metadata=metadata))
+        return asyncio.run(
+            self.run_flow(name, payload=payload, metadata=metadata, run_id=run_id)
+        )
 
     async def wait_for(self, *names: str) -> List[FlowExecution]:
         tasks: Iterable[asyncio.Task[FlowExecution]]
@@ -421,28 +481,88 @@ class FlowOrchestrator:
         *,
         metadata: Optional[Dict[str, Any]] = None,
         schedule_id: Optional[str] = None,
+        run_id: Optional[str] = None,
     ) -> FlowExecution:
+        run_identifier = run_id or uuid.uuid4().hex
         started_at = _utcnow()
-        metadata = dict(metadata or {})
+        metadata_dict = dict(metadata or {})
+        task = asyncio.current_task()
+        if self._on_execution_start is not None:
+            try:
+                self._on_execution_start(
+                    run_identifier,
+                    registration.name,
+                    task,
+                    payload,
+                    dict(metadata_dict),
+                    schedule_id,
+                    started_at,
+                )
+            except Exception:  # pragma: no cover - callback errors should not break execution
+                self.logger.exception("Execution start callback failed for flow '%s'", registration.name)
+
         configure_logging(registration.deployment.global_config)
-        async with registration.create_executor() as executor:
-            results = await executor.run(initial_payload=payload)
-            trace = executor.trace
-        finished_at = _utcnow()
-        execution = FlowExecution(
-            flow_name=registration.name,
-            results=results,
-            payload=payload,
-            trace=trace,
-            started_at=started_at,
-            finished_at=finished_at,
-            schedule_id=schedule_id,
-            metadata=metadata,
-        )
-        self.logger.debug(
-            "Flow '%s' finished in %.3fs", registration.name, (finished_at - started_at).total_seconds()
-        )
-        return execution
+        try:
+            async with registration.create_executor() as executor:
+                results = await executor.run(initial_payload=payload)
+                trace = executor.trace
+        except asyncio.CancelledError:
+            finished_at = _utcnow()
+            if self._on_execution_cancelled is not None:
+                try:
+                    self._on_execution_cancelled(
+                        run_identifier,
+                        registration.name,
+                        payload,
+                        dict(metadata_dict),
+                        schedule_id,
+                        started_at,
+                        finished_at,
+                    )
+                except Exception:  # pragma: no cover - defensive callback handling
+                    self.logger.exception("Execution cancelled callback failed for flow '%s'", registration.name)
+            raise
+        except Exception as exc:
+            finished_at = _utcnow()
+            if self._on_execution_error is not None:
+                try:
+                    self._on_execution_error(
+                        run_identifier,
+                        registration.name,
+                        payload,
+                        dict(metadata_dict),
+                        schedule_id,
+                        started_at,
+                        finished_at,
+                        exc,
+                    )
+                except Exception:  # pragma: no cover - defensive callback handling
+                    self.logger.exception("Execution error callback failed for flow '%s'", registration.name)
+            raise
+        else:
+            finished_at = _utcnow()
+            execution = FlowExecution(
+                id=run_identifier,
+                flow_name=registration.name,
+                results=results,
+                payload=payload,
+                trace=trace,
+                started_at=started_at,
+                finished_at=finished_at,
+                schedule_id=schedule_id,
+                metadata=metadata_dict,
+            )
+            if self._on_execution_success is not None:
+                try:
+                    self._on_execution_success(execution)
+                except Exception:  # pragma: no cover - defensive callback handling
+                    self.logger.exception("Execution success callback failed for flow '%s'", registration.name)
+            self.logger.debug(
+                "Flow '%s' finished in %.3fs",
+                registration.name,
+                (finished_at - started_at).total_seconds(),
+            )
+            return execution
 
     def _track_task(self, registration: FlowRegistration, task: asyncio.Task[FlowExecution]) -> None:
         task_set = self._active_tasks.setdefault(registration.name, set())

--- a/dashboard/pages/operations.py
+++ b/dashboard/pages/operations.py
@@ -341,7 +341,13 @@ def _inject_auto_refresh(interval_seconds: Optional[int]) -> None:
     components.html(
         f"""
             <script>
-            const rerun = () => window.parent.postMessage({{ type: 'streamlit:rerun' }}, '*');
+            const rerun = () => {{
+                const message = {{
+                    isStreamlitMessage: true,
+                    type: 'streamlit:rerunScript',
+                }};
+                window.parent.postMessage(message, '*');
+            }};
             if (window.__conductorRefresh) {{ clearTimeout(window.__conductorRefresh); }}
             window.__conductorRefresh = setTimeout(rerun, {millis});
             </script>

--- a/dashboard/services/runtime.py
+++ b/dashboard/services/runtime.py
@@ -184,8 +184,11 @@ class OrchestratorRuntime:
         execution = self._run_coroutine(
             self._run_flow_once(name, payload, metadata, schedule_id)
         )
-        summary = self._summarise_execution(execution, default_status="completed")
-        self._record_summary(summary)
+        summary = self._summarise_execution(
+            execution,
+            run_id=execution.id,
+            default_status="completed",
+        )
         return summary
 
     def schedule_flow(
@@ -284,7 +287,12 @@ class OrchestratorRuntime:
     # ------------------------------------------------------------------
     def _run_loop(self) -> None:
         asyncio.set_event_loop(self._loop)
-        self._orchestrator = FlowOrchestrator()
+        self._orchestrator = FlowOrchestrator(
+            on_execution_start=self._handle_execution_start,
+            on_execution_success=self._handle_execution_success,
+            on_execution_error=self._handle_execution_error,
+            on_execution_cancelled=self._handle_execution_cancelled,
+        )
         self._ready.set()
         self._loop.run_forever()
         pending = asyncio.all_tasks(loop=self._loop)
@@ -325,6 +333,7 @@ class OrchestratorRuntime:
                 payload=payload,
                 metadata=metadata,
                 schedule_id=schedule_id,
+                run_id=run_id,
             )
             entry = _RunEntry(
                 id=run_id,
@@ -336,46 +345,6 @@ class OrchestratorRuntime:
                 schedule_id=schedule_id,
             )
             self._active_runs[run_id] = entry
-
-            def _done_callback(fut: asyncio.Future[FlowExecution]) -> None:
-                finished_at = datetime.now(timezone.utc)
-                try:
-                    execution = fut.result()
-                    summary = self._summarise_execution(
-                        execution,
-                        run_id=run_id,
-                    )
-                except asyncio.CancelledError:
-                    duration = (finished_at - entry.started_at).total_seconds()
-                    summary = RunSummary(
-                        id=run_id,
-                        flow_name=name,
-                        status="cancelled",
-                        started_at=entry.started_at,
-                        finished_at=finished_at,
-                        duration=duration,
-                        schedule_id=entry.schedule_id,
-                        payload_preview=entry.payload,
-                        metadata=dict(entry.metadata),
-                        error="Run cancelled",
-                    )
-                except Exception as exc:  # pragma: no cover - surfaced in UI
-                    duration = (finished_at - entry.started_at).total_seconds()
-                    summary = RunSummary(
-                        id=run_id,
-                        flow_name=name,
-                        status="error",
-                        started_at=entry.started_at,
-                        finished_at=finished_at,
-                        duration=duration,
-                        schedule_id=entry.schedule_id,
-                        payload_preview=entry.payload,
-                        metadata=dict(entry.metadata),
-                        error=str(exc),
-                    )
-                self._completed.put((run_id, summary))
-
-            task.add_done_callback(_done_callback)
             return RunSummary(
                 id=run_id,
                 flow_name=name,
@@ -404,6 +373,103 @@ class OrchestratorRuntime:
             metadata=metadata,
             schedule_id=schedule_id,
         )
+
+    def _handle_execution_start(
+        self,
+        run_id: str,
+        flow_name: str,
+        task: Optional[asyncio.Task[FlowExecution]],
+        payload: Any,
+        metadata: Dict[str, Any],
+        schedule_id: Optional[str],
+        started_at: datetime,
+    ) -> None:
+        loop_task = task or asyncio.current_task()
+        if loop_task is None:
+            return
+        metadata_copy = dict(metadata or {})
+        entry = self._active_runs.get(run_id)
+        if entry is None:
+            entry = _RunEntry(
+                id=run_id,
+                flow_name=flow_name,
+                task=loop_task,
+                started_at=started_at,
+                payload=payload,
+                metadata=metadata_copy,
+                schedule_id=schedule_id,
+            )
+            self._active_runs[run_id] = entry
+        else:
+            entry.task = loop_task
+            entry.started_at = started_at
+            entry.payload = payload
+            entry.metadata = metadata_copy
+            entry.schedule_id = schedule_id
+
+    def _handle_execution_success(self, execution: FlowExecution) -> None:
+        summary = self._summarise_execution(
+            execution,
+            run_id=execution.id,
+            default_status="completed",
+        )
+        self._active_runs.pop(execution.id, None)
+        self._completed.put((execution.id, summary))
+
+    def _handle_execution_error(
+        self,
+        run_id: str,
+        flow_name: str,
+        payload: Any,
+        metadata: Dict[str, Any],
+        schedule_id: Optional[str],
+        started_at: datetime,
+        finished_at: datetime,
+        error: BaseException,
+    ) -> None:
+        metadata_copy = dict(metadata or {})
+        duration = (finished_at - started_at).total_seconds()
+        summary = RunSummary(
+            id=run_id,
+            flow_name=flow_name,
+            status="error",
+            started_at=started_at,
+            finished_at=finished_at,
+            duration=duration,
+            schedule_id=schedule_id,
+            payload_preview=payload,
+            metadata=metadata_copy,
+            error=str(error),
+        )
+        self._active_runs.pop(run_id, None)
+        self._completed.put((run_id, summary))
+
+    def _handle_execution_cancelled(
+        self,
+        run_id: str,
+        flow_name: str,
+        payload: Any,
+        metadata: Dict[str, Any],
+        schedule_id: Optional[str],
+        started_at: datetime,
+        finished_at: datetime,
+    ) -> None:
+        metadata_copy = dict(metadata or {})
+        duration = (finished_at - started_at).total_seconds()
+        summary = RunSummary(
+            id=run_id,
+            flow_name=flow_name,
+            status="cancelled",
+            started_at=started_at,
+            finished_at=finished_at,
+            duration=duration,
+            schedule_id=schedule_id,
+            payload_preview=payload,
+            metadata=metadata_copy,
+            error="Run cancelled",
+        )
+        self._active_runs.pop(run_id, None)
+        self._completed.put((run_id, summary))
 
     def _summarise_execution(
         self,

--- a/dashboard/state.py
+++ b/dashboard/state.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import os
+from functools import wraps
 from typing import Any, Dict, Optional
 
 import streamlit as st
@@ -16,23 +17,59 @@ _RUNTIME_KEY = "dashboard_runtime"
 _GLOBAL_CONFIG_KEY = "dashboard_global_config"
 
 
+if hasattr(st, "cache_resource"):
+    _runtime_cache = st.cache_resource
+elif hasattr(st, "experimental_singleton"):
+    _runtime_cache = st.experimental_singleton  # type: ignore[attr-defined]
+else:  # pragma: no cover - compatibility with very old Streamlit releases
+
+    def _runtime_cache(func):  # type: ignore[no-redef]
+        cache: Dict[str, OrchestratorRuntime] = {}
+
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            if "value" not in cache:
+                cache["value"] = func(*args, **kwargs)
+            return cache["value"]
+
+        def clear() -> None:
+            cache.pop("value", None)
+
+        wrapper.clear = clear  # type: ignore[attr-defined]
+        return wrapper
+
+
+@_runtime_cache
+def _get_shared_runtime() -> OrchestratorRuntime:
+    """Create or return the shared orchestrator runtime for the dashboard."""
+
+    return OrchestratorRuntime()
+
+
+def _initialise_runtime(runtime: OrchestratorRuntime) -> None:
+    if getattr(runtime, "_dashboard_initialised", False):
+        return
+
+    failures = []
+    for name, deployment in load_saved_deployments().items():
+        try:
+            runtime.register_flow(deployment, replace=True)
+        except Exception as exc:  # pragma: no cover - restoration feedback
+            failures.append((name, str(exc)))
+    runtime._dashboard_initialised = True  # type: ignore[attr-defined]
+    runtime._dashboard_restore_failures = failures  # type: ignore[attr-defined]
+
+
 def get_runtime() -> OrchestratorRuntime:
-    if _RUNTIME_KEY not in st.session_state:
-        runtime = OrchestratorRuntime()
-        failures = []
-        for name, deployment in load_saved_deployments().items():
-            try:
-                runtime.register_flow(deployment, replace=True)
-            except Exception as exc:  # pragma: no cover - restoration feedback
-                failures.append((name, str(exc)))
-        st.session_state[_RUNTIME_KEY] = runtime
-        if failures:
-            st.session_state["_runtime_restore_failures"] = failures
-    runtime = st.session_state[_RUNTIME_KEY]
-    failures = st.session_state.pop("_runtime_restore_failures", None)
-    if failures:
+    runtime = _get_shared_runtime()
+    st.session_state[_RUNTIME_KEY] = runtime
+    _initialise_runtime(runtime)
+
+    failures = getattr(runtime, "_dashboard_restore_failures", [])  # type: ignore[attr-defined]
+    if failures and not st.session_state.get("_runtime_restore_reported"):
         for name, message in failures:
             st.warning(f"Impossibile ripristinare il flow '{name}': {message}")
+        st.session_state["_runtime_restore_reported"] = True
     return runtime
 
 
@@ -84,10 +121,14 @@ def mark_global_config_clean() -> None:
 
 
 def reset_state() -> None:
-    if _RUNTIME_KEY in st.session_state:
-        runtime: OrchestratorRuntime = st.session_state[_RUNTIME_KEY]
+    runtime: Optional[OrchestratorRuntime] = st.session_state.pop(_RUNTIME_KEY, None)
+    if runtime is not None:
         runtime.shutdown()
-        st.session_state.pop(_RUNTIME_KEY, None)
+    try:
+        _get_shared_runtime.clear()  # type: ignore[attr-defined]
+    except Exception:  # pragma: no cover - cache cleanup best effort
+        pass
+    st.session_state.pop("_runtime_restore_reported", None)
     st.session_state.pop(_GLOBAL_CONFIG_KEY, None)
 
 


### PR DESCRIPTION
## Summary
- switch the Streamlit auto-refresh script to the current `streamlit:rerunScript` message format so the toggle works again
- share a cached OrchestratorRuntime instance across dashboard sessions with fallbacks for older Streamlit versions so schedules remain visible after reloads
- add execution lifecycle callbacks in the orchestrator/runtime to surface scheduled runs in monitoring and history, including cancellation/error handling

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d6a36b45808327ac45bf78484d4318